### PR TITLE
fix intro/recap start_ms can be null and fix delete existing segments

### DIFF
--- a/TheIntroDB/Api/SegmentTimestamp.cs
+++ b/TheIntroDB/Api/SegmentTimestamp.cs
@@ -20,22 +20,19 @@ public class SegmentTimestamp
     public long? EndMs { get; set; }
 
     /// <summary>
-    /// Returns whether this segment has usable start and end (for intro/recap both required; for credits/preview start required).
+    /// Returns whether this segment has a usable time range.
+    /// For intro/recap, start is optional and end is required.
+    /// For credits/preview, start is required and end is optional.
     /// </summary>
     /// <param name="endRequired">True if end time is required (intro/recap).</param>
     /// <returns>True if the segment has a valid range.</returns>
     public bool HasValidRange(bool endRequired)
     {
-        if (StartMs is null)
-        {
-            return false;
-        }
-
         if (endRequired)
         {
             return EndMs.HasValue && EndMs.Value > (StartMs ?? 0);
         }
 
-        return true;
+        return StartMs.HasValue;
     }
 }

--- a/TheIntroDB/Providers/TheIntroDbSegmentProvider.cs
+++ b/TheIntroDB/Providers/TheIntroDbSegmentProvider.cs
@@ -118,7 +118,9 @@ public class TheIntroDbSegmentProvider : IMediaSegmentProvider
             if (segmentManager.HasSegments(request.ItemId))
             {
                 _logger.LogDebug("Skipping {Name}: already has segments (IgnoreMediaWithExistingSegments enabled)", item.Name);
-                return Array.Empty<MediaSegmentDto>();
+
+                // Return existing segments unchanged to prevent Jellyfin from deleting them.
+                return request.ExistingSegments.ToList();
             }
         }
 


### PR DESCRIPTION
## Description

1. Reference documentation: https://theintrodb.org/docs. The start_ms for both the intro and the recap can be null.

2. When `IgnoreMediaWithExistingSegments` is enabled, returning an empty array will cause Jellyfin to delete existing segments. To retain segments, need to return the existing segments array.  
Jellyfin code reference: https://github.com/jellyfin/jellyfin/blob/bc074b5283add16818ce598890f53ce9432cd4ad/Jellyfin.Server.Implementations/MediaSegments/MediaSegmentManager.cs#L127

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
