### PR TITLE
fix: rate-limit safety margin and preserve segments on transient API failures

### DIFF
--- a/TheIntroDB.Tests/RateLimitSafetyTests.cs
+++ b/TheIntroDB.Tests/RateLimitSafetyTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Reflection;
+using TheIntroDB.Api;
+using Xunit;
+
+namespace TheIntroDB.Tests;
+
+public class RateLimitSafetyTests
+{
+    [Fact]
+    public void RequestPacingKeepsThirtyStartsOutsideTenSecondWindow()
+    {
+        var field = typeof(TheIntroDbClient).GetField(
+            "MinDelayBetweenRequests",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        var minimumDelay = Assert.IsType<TimeSpan>(field?.GetValue(null));
+
+        Assert.True(
+            TimeSpan.FromTicks(minimumDelay.Ticks * 29) >= TimeSpan.FromSeconds(10),
+            $"Thirty request starts can fit inside ten seconds with a {minimumDelay.TotalMilliseconds} ms delay.");
+    }
+
+    public static TheoryData<bool, long?, long?, bool> RangeCases => new()
+    {
+        { true, null, 5000L, true },   // intro: null start, end set
+        { true, 1000L, 2000L, true },  // intro: normal range
+        { true, 1000L, 1000L, false }, // end == start is invalid
+        { true, 1000L, null, false },  // intro: missing end is invalid
+        { false, 1000L, null, true },  // credits: start set, end optional
+        { false, null, 5000L, true },  // credits: end set, start optional (emby parity)
+        { false, null, null, false }   // neither boundary
+    };
+
+    [Theory]
+    [MemberData(nameof(RangeCases))]
+    public void HasValidRangeAcceptsEitherBoundaryWhenEndIsOptional(bool endRequired, long? startMs, long? endMs, bool expected)
+    {
+        var stamp = new SegmentTimestamp { StartMs = startMs, EndMs = endMs };
+        Assert.Equal(expected, stamp.HasValidRange(endRequired));
+    }
+
+    [Fact]
+    public void FetchResultDistinguishesRateLimitFromNotFoundFromError()
+    {
+        var rateLimited = MediaFetchResult.RateLimited();
+        Assert.True(rateLimited.IsRateLimited);
+        Assert.False(rateLimited.IsNotFound);
+        Assert.False(rateLimited.IsError);
+
+        var notFound = MediaFetchResult.NotFound();
+        Assert.True(notFound.IsNotFound);
+        Assert.False(notFound.IsRateLimited);
+        Assert.False(notFound.IsError);
+
+        var error = MediaFetchResult.Error();
+        Assert.True(error.IsError);
+        Assert.False(error.IsNotFound);
+        Assert.False(error.IsRateLimited);
+
+        var success = MediaFetchResult.Success(new MediaResponse());
+        Assert.False(success.IsError);
+        Assert.False(success.IsRateLimited);
+        Assert.False(success.IsNotFound);
+        Assert.NotNull(success.Response);
+    }
+}

--- a/TheIntroDB.Tests/TheIntroDB.Tests.csproj
+++ b/TheIntroDB.Tests/TheIntroDB.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../TheIntroDB/TheIntroDB.csproj" />
+  </ItemGroup>
+</Project>

--- a/TheIntroDB.sln
+++ b/TheIntroDB.sln
@@ -1,6 +1,8 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-#
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TheIntroDB", "TheIntroDB\TheIntroDB.csproj", "{D921B930-CF91-406F-ACBC-08914DCD0D34}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TheIntroDB.Tests", "TheIntroDB.Tests\TheIntroDB.Tests.csproj", "{368DF49B-F971-4B9F-B3B0-5D31BF3238BA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -12,7 +14,7 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-        {D921B930-CF91-406F-ACBC-08914DCD0D34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D921B930-CF91-406F-ACBC-08914DCD0D34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D921B930-CF91-406F-ACBC-08914DCD0D34}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D921B930-CF91-406F-ACBC-08914DCD0D34}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{D921B930-CF91-406F-ACBC-08914DCD0D34}.Debug|x64.Build.0 = Debug|Any CPU
@@ -24,5 +26,20 @@ Global
 		{D921B930-CF91-406F-ACBC-08914DCD0D34}.Release|x64.Build.0 = Release|Any CPU
 		{D921B930-CF91-406F-ACBC-08914DCD0D34}.Release|x86.ActiveCfg = Release|Any CPU
 		{D921B930-CF91-406F-ACBC-08914DCD0D34}.Release|x86.Build.0 = Release|Any CPU
+		{368DF49B-F971-4B9F-B3B0-5D31BF3238BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{368DF49B-F971-4B9F-B3B0-5D31BF3238BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{368DF49B-F971-4B9F-B3B0-5D31BF3238BA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{368DF49B-F971-4B9F-B3B0-5D31BF3238BA}.Debug|x64.Build.0 = Debug|Any CPU
+		{368DF49B-F971-4B9F-B3B0-5D31BF3238BA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{368DF49B-F971-4B9F-B3B0-5D31BF3238BA}.Debug|x86.Build.0 = Debug|Any CPU
+		{368DF49B-F971-4B9F-B3B0-5D31BF3238BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{368DF49B-F971-4B9F-B3B0-5D31BF3238BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{368DF49B-F971-4B9F-B3B0-5D31BF3238BA}.Release|x64.ActiveCfg = Release|Any CPU
+		{368DF49B-F971-4B9F-B3B0-5D31BF3238BA}.Release|x64.Build.0 = Release|Any CPU
+		{368DF49B-F971-4B9F-B3B0-5D31BF3238BA}.Release|x86.ActiveCfg = Release|Any CPU
+		{368DF49B-F971-4B9F-B3B0-5D31BF3238BA}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/TheIntroDB/Api/MediaFetchResult.cs
+++ b/TheIntroDB/Api/MediaFetchResult.cs
@@ -1,0 +1,66 @@
+namespace TheIntroDB.Api;
+
+/// <summary>
+/// Result of a TheIntroDB API media fetch. Distinguishes transient rate
+/// limits and errors from definitive not-found answers so callers never
+/// treat a temporary failure as an empty dataset.
+/// </summary>
+public sealed class MediaFetchResult
+{
+    private MediaFetchResult(MediaResponse? response, bool isRateLimited, bool isError, bool isNotFound)
+    {
+        Response = response;
+        IsRateLimited = isRateLimited;
+        IsError = isError;
+        IsNotFound = isNotFound;
+    }
+
+    /// <summary>
+    /// Gets the parsed media response, or null when there is no data.
+    /// </summary>
+    public MediaResponse? Response { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the provider rate limit was hit
+    /// (HTTP 429 or the local rate-limit gate). Transient; retry later.
+    /// </summary>
+    public bool IsRateLimited { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the request failed transiently
+    /// (HTTP error or network exception). Retry later.
+    /// </summary>
+    public bool IsError { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the API definitively has no data
+    /// for this item (missing IDs, missing season/episode, or HTTP 404).
+    /// </summary>
+    public bool IsNotFound { get; }
+
+    /// <summary>
+    /// Creates a success result carrying the parsed media response (may be null
+    /// when the API answered 200 with no usable body).
+    /// </summary>
+    /// <param name="response">The parsed media response, or null.</param>
+    /// <returns>A success result.</returns>
+    public static MediaFetchResult Success(MediaResponse? response) => new(response, false, false, false);
+
+    /// <summary>
+    /// Creates a not-found result: the API definitively has no data for the item.
+    /// </summary>
+    /// <returns>A not-found result.</returns>
+    public static MediaFetchResult NotFound() => new(null, false, false, true);
+
+    /// <summary>
+    /// Creates a rate-limited result: transient, retry later.
+    /// </summary>
+    /// <returns>A rate-limited result.</returns>
+    public static MediaFetchResult RateLimited() => new(null, true, false, false);
+
+    /// <summary>
+    /// Creates an error result: transient failure, retry later.
+    /// </summary>
+    /// <returns>An error result.</returns>
+    public static MediaFetchResult Error() => new(null, false, true, false);
+}

--- a/TheIntroDB/Api/SegmentTimestamp.cs
+++ b/TheIntroDB/Api/SegmentTimestamp.cs
@@ -33,6 +33,6 @@ public class SegmentTimestamp
             return EndMs.HasValue && EndMs.Value > (StartMs ?? 0);
         }
 
-        return StartMs.HasValue;
+        return StartMs.HasValue || EndMs.HasValue;
     }
 }

--- a/TheIntroDB/Api/TheIntroDbClient.cs
+++ b/TheIntroDB/Api/TheIntroDbClient.cs
@@ -16,7 +16,7 @@ namespace TheIntroDB.Api;
 /// </summary>
 public class TheIntroDbClient
 {
-    private const int MaxRequestsPerWindow = 30;
+    private const int MaxRequestsPerWindow = 25;
     private static readonly TimeSpan RateLimitWindow = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan MinDelayBetweenRequests = TimeSpan.FromMilliseconds(RateLimitWindow.TotalMilliseconds / MaxRequestsPerWindow);
 
@@ -51,8 +51,8 @@ public class TheIntroDbClient
     /// <param name="episode">Episode number (required for TV).</param>
     /// <param name="durationMs">Optional total video duration (milliseconds). Recommended for best matching release version.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Media response or null if not found or error.</returns>
-    public async Task<MediaResponse?> GetMediaAsync(
+    /// <returns>Media fetch result distinguishing rate limits, errors and not-found.</returns>
+    public async Task<MediaFetchResult> GetMediaAsync(
         int? tmdbId,
         int? tvdbId,
         string? imdbId,
@@ -85,7 +85,7 @@ public class TheIntroDbClient
                     ["id_source"] = idSource,
                     ["has_theintrodb_api_key"] = !string.IsNullOrWhiteSpace(_plugin.Configuration?.ApiKey) ? 1 : 0
                 });
-            return null;
+            return MediaFetchResult.RateLimited();
         }
 
         var config = _plugin.Configuration ?? new PluginConfiguration();
@@ -93,7 +93,7 @@ public class TheIntroDbClient
 
         if (!hasTmdb && !hasTvdb && !hasImdb)
         {
-            return null;
+            return MediaFetchResult.NotFound();
         }
 
         var queryParams = new List<string>(4);
@@ -115,7 +115,7 @@ public class TheIntroDbClient
             if (!season.HasValue || !episode.HasValue)
             {
                 _logger.LogWarning("Skipping TV show request: missing season ({Season}) or episode ({Episode}) for tmdbId={TmdbId}, tvdbId={TvdbId}, imdbId={ImdbId}", season, episode, tmdbIdValue, tvdbIdValue, imdbId ?? "(none)");
-                return null;
+                return MediaFetchResult.NotFound();
             }
 
             queryParams.Add($"season={season}");
@@ -168,7 +168,7 @@ public class TheIntroDbClient
                         ["id_source"] = idSource,
                         ["has_theintrodb_api_key"] = !string.IsNullOrWhiteSpace(config.ApiKey) ? 1 : 0
                     });
-                return null;
+                return MediaFetchResult.RateLimited();
             }
 
             if (!response.IsSuccessStatusCode)
@@ -187,7 +187,13 @@ public class TheIntroDbClient
                         ["id_source"] = idSource,
                         ["has_theintrodb_api_key"] = !string.IsNullOrWhiteSpace(config.ApiKey) ? 1 : 0
                     });
-                return null;
+
+                if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                {
+                    return MediaFetchResult.NotFound();
+                }
+
+                return MediaFetchResult.Error();
             }
 
             var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -213,7 +219,7 @@ public class TheIntroDbClient
                     ["credits_count"] = result?.Credits?.Count ?? 0,
                     ["preview_count"] = result?.Preview?.Count ?? 0
                 });
-            return result;
+            return MediaFetchResult.Success(result);
         }
         catch (Exception ex)
         {
@@ -229,7 +235,7 @@ public class TheIntroDbClient
                     ["id_source"] = idSource,
                     ["has_theintrodb_api_key"] = !string.IsNullOrWhiteSpace(config.ApiKey) ? 1 : 0
                 });
-            return null;
+            return MediaFetchResult.Error();
         }
     }
 

--- a/TheIntroDB/Providers/TheIntroDbSegmentProvider.cs
+++ b/TheIntroDB/Providers/TheIntroDbSegmentProvider.cs
@@ -181,12 +181,26 @@ public class TheIntroDbSegmentProvider : IMediaSegmentProvider
         long? durationMs = item.RunTimeTicks.HasValue && item.RunTimeTicks.Value > 0
             ? item.RunTimeTicks.Value / TimeSpan.TicksPerMillisecond
             : null;
-        var media = await client.GetMediaAsync(tmdbId, tvdbId, imdbId, isMovie, season, episode, durationMs, cancellationToken).ConfigureAwait(false);
-        if (media is null)
+        var result = await client.GetMediaAsync(tmdbId, tvdbId, imdbId, isMovie, season, episode, durationMs, cancellationToken).ConfigureAwait(false);
+        if (result.IsRateLimited || result.IsError)
+        {
+            // Never treat a transient rate limit or error as an empty dataset:
+            // returning empty would make Jellyfin delete the segments this
+            // plugin already stored for the item.
+            _logger.LogWarning(
+                "TheIntroDB API request was {Status} for {Name}; preserving existing segments",
+                result.IsRateLimited ? "rate limited" : "an error",
+                item.Name);
+            return GetExistingSegments(request);
+        }
+
+        if (result.IsNotFound || result.Response is null)
         {
             _logger.LogInformation("TheIntroDB API returned no data for {Name}", item.Name);
             return Array.Empty<MediaSegmentDto>();
         }
+
+        var media = result.Response;
 
         long? runTimeTicks = item.RunTimeTicks;
 


### PR DESCRIPTION
## Summary

Audit of the Jellyfin plugin against the safety fixes that landed in the Emby plugin (#22/#23/#26/#27) found the same two issues, now fixed:

1. **Rate-limit pacing at the exact provider ceiling.** `MaxRequestsPerWindow` was 30 (333 ms spacing = exactly 30 requests / 10 s, zero margin for rolling-window accounting or scheduler jitter — the same root cause as emby #26). Now **25 per 10 s (400 ms)**, a ~20% safety margin. Regression test proves 30 request starts cannot fit inside a 10 s window.
2. **Transient 429/errors were indistinguishable from "no data".** `GetMediaAsync` returned `null` for rate limits, HTTP errors, 404s and empty answers alike, and the provider returned `Array.Empty` in every case — which makes Jellyfin's segment manager delete the segments this plugin already stored for the item on a transient failure. The client now returns a typed `MediaFetchResult` (RateLimited / Error / NotFound / Success) and the provider **returns the item's existing segments** on rate limit or error, preserving them (same no-op pattern already used for filtered-out items). Only definitive not-found answers return empty.
3. **`SegmentTimestamp.HasValidRange` parity with Emby** (emby fix 24bafb2): when the end is optional, either boundary is now sufficient (`StartMs.HasValue || EndMs.HasValue`).
4. **First test project** (`TheIntroDB.Tests`, net10.0, xunit) — the repo previously had zero automated tests. Covers pacing, range validation, and fetch-result semantics.

## Verification

- Release build: 0 errors, 0 warnings (plugin keeps its StyleCop/TreatWarningsAsErrors gates)
- tests: **9 passed** (net10.0)
- `git diff --check`: clean

## Notes

- Base is `main` (net9.0 + Jellyfin 10.11.6) on purpose, so this stays independent of the in-flight `fix/jf-12-0-compatibility` branch. The two will merge cleanly; the provider/segment-changes touch different regions.
- Not addressed here (separate concerns): the JF 12.0 compatibility work on `fix/jf-12-0-compatibility`, and the lack of a `Preview`-style read-only task (Jellyfin's segment manager owns storage, unlike Emby's plugin-managed SQLite).
