### PR TITLE
fix: guard CTS disposal in usage reporting service against double dispose

### DIFF
--- a/TheIntroDB.Tests/TheIntroDB.Tests.csproj
+++ b/TheIntroDB.Tests/TheIntroDB.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../TheIntroDB/TheIntroDB.csproj" />

--- a/TheIntroDB.Tests/TheIntroDbUsageReportingServiceTests.cs
+++ b/TheIntroDB.Tests/TheIntroDbUsageReportingServiceTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.MediaSegments;
+using MediaBrowser.Controller.Session;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace TheIntroDB.Tests;
+
+/// <summary>
+/// Regression tests for https://github.com/TheIntroDB/jellyfin-plugin/issues/23:
+/// Jellyfin crashes with an unhandled <see cref="ObjectDisposedException"/> on shutdown
+/// or restart because the usage-reporting service's <see cref="TheIntroDbUsageReportingService.Dispose"/>
+/// re-cancels and re-disposes a <see cref="CancellationTokenSource"/> that
+/// <see cref="TheIntroDbUsageReportingService.StopAsync"/> had already disposed.
+/// </summary>
+public class TheIntroDbUsageReportingServiceTests
+{
+    [Fact]
+    public async Task Dispose_AfterStopAsync_DoesNotThrow()
+    {
+        var service = CreateService();
+
+        // The generic host calls StopAsync, then disposes the hosted service.
+        await service.StopAsync(CancellationToken.None);
+        service.Dispose();
+    }
+
+    [Fact]
+    public void Dispose_Twice_DoesNotThrow()
+    {
+        var service = CreateService();
+
+        service.Dispose();
+        service.Dispose();
+    }
+
+    private static TheIntroDbUsageReportingService CreateService()
+        => new(
+            new Mock<ISessionManager>().Object,
+            new Mock<IMediaSegmentManager>().Object,
+            new Mock<ILibraryManager>().Object,
+            NullLogger<TheIntroDbUsageReportingService>.Instance);
+}

--- a/TheIntroDB/TheIntroDB.csproj
+++ b/TheIntroDB/TheIntroDB.csproj
@@ -27,6 +27,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="TheIntroDB.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
     <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />

--- a/TheIntroDB/TheIntroDbUsageReportingService.cs
+++ b/TheIntroDB/TheIntroDbUsageReportingService.cs
@@ -33,6 +33,7 @@ internal sealed class TheIntroDbUsageReportingService : IHostedService, IDisposa
     private readonly CancellationTokenSource _cts = new();
     private readonly ConcurrentDictionary<long, Task> _pendingTasks = new();
     private static readonly char[] CommaSeparator = { ',' };
+    private int _ctsDisposed;
 
     public TheIntroDbUsageReportingService(
         ISessionManager sessionManager,
@@ -79,11 +80,27 @@ internal sealed class TheIntroDbUsageReportingService : IHostedService, IDisposa
             // Swallow task exceptions during shutdown — they were already logged
         }
 
-        _cts.Dispose();
+        DisposeCts();
     }
 
     public void Dispose()
     {
+        DisposeCts();
+    }
+
+    /// <summary>
+    /// Cancels and disposes the <see cref="CancellationTokenSource"/> exactly once.
+    /// The host calls <see cref="StopAsync"/> and then disposes the service, so both
+    /// paths run during shutdown — without a guard the second call would throw
+    /// <see cref="ObjectDisposedException"/>.
+    /// </summary>
+    private void DisposeCts()
+    {
+        if (Interlocked.Exchange(ref _ctsDisposed, 1) != 0)
+        {
+            return;
+        }
+
         _cts.Cancel();
         _cts.Dispose();
     }


### PR DESCRIPTION
## Bug Description

Closes #23

Jellyfin crashes with an unhandled `System.ObjectDisposedException: The CancellationTokenSource has been disposed.` on shutdown/restart. The exception is thrown from `TheIntroDbUsageReportingService.Dispose()`.

## Root Cause

The service is registered with `AddHostedService<TheIntroDbUsageReportingService>()`. During shutdown the generic host calls `StopAsync()` first, then disposes the hosted service (which `Dispose()`es the DI singleton).

`StopAsync()` already cancelled **and disposed** the `CancellationTokenSource` (`_cts.Dispose()`), so the subsequent `Dispose()` re-called `_cts.Cancel()` on the already-disposed CTS — which throws `ObjectDisposedException`:

```
System.ObjectDisposedException: The CancellationTokenSource has been disposed.
   at TheIntroDB.TheIntroDbUsageReportingService.Dispose()
   at ...ServiceLookup.ServiceProviderEngineScope...
   at ...Host.DisposeAsync()...
```

## Fix

Route both shutdown paths through a single guarded helper, `DisposeCts()`, that tears down the CTS exactly once (idempotent via `Interlocked.Exchange`). Whichever of `StopAsync`/`Dispose` runs first owns the teardown; the second call becomes a no-op.

```csharp
private void DisposeCts()
{
    if (Interlocked.Exchange(ref _ctsDisposed, 1) != 0)
    {
        return;
    }

    _cts.Cancel();
    _cts.Dispose();
}
```

Also added `<InternalsVisibleTo Include="TheIntroDB.Tests" />` so the internal service can be regression-tested.

## How to Verify

1. `dotnet test TheIntroDB.Tests/TheIntroDB.Tests.csproj -c Release`
2. All 14 tests pass (12 existing + 2 new).

## Test Plan

- [x] Added regression test for this bug (`Dispose_AfterStopAsync_DoesNotThrow`, `Dispose_Twice_DoesNotThrow`)
- [x] Verified the new tests **fail with the reported `ObjectDisposedException`** against the pre-fix code, and pass with the fix
- [x] Existing tests still pass
- [ ] Manual verification: restart/shut down Jellyfin with the plugin enabled

## Risk Assessment

Low — the change only affects the shutdown path; runtime behavior (event subscription, segment reporting) is untouched.
